### PR TITLE
ci: build the site from the Gemfile instead of the github-pages gem

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,6 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # Build from the Gemfile rather than actions/jekyll-build-pages, whose
+      # github-pages gem pins Jekyll 3.10 and so cannot satisfy the `jekyll
+      # ~> 4.3.4` pin here. That action warned and silently built with 3.10.
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
       - name: Fetch data and convert to markdown
         run: |
           make ^_datasets-yaml
@@ -41,10 +49,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
+        run: bundle exec jekyll build --source ./ --destination ./_site
+        env:
+          JEKYLL_ENV: production
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,12 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.1-x64-mingw-ucrt)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.29.3-x64-mingw-ucrt)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.29.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -50,6 +54,8 @@ GEM
     mercenary (0.4.0)
     nokogiri (1.19.1-x64-mingw-ucrt)
       racc (~> 1.4)
+    nokogiri (1.19.1-x86_64-linux-gnu)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
@@ -77,6 +83,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.83.4-x64-mingw-ucrt)
       google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-linux-gnu)
+      google-protobuf (~> 4.29)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -84,6 +92,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.3.4)


### PR DESCRIPTION
Every build logged this:

```
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
##[warning]The github-pages gem can't satisfy your Gemfile's dependencies...
      GitHub Pages: github-pages v232
      GitHub Pages: jekyll v3.10.0
```

## Root cause

`actions/jekyll-build-pages` ships the `github-pages` gem, which pins **Jekyll 3.10**. Our `Gemfile` pins **`jekyll ~> 4.3.4`**. The action cannot resolve the two, warns, and falls back to its own bundle.

The consequence is bigger than the warning: **the published site was built by Jekyll 3.10, while the Gemfile, `Gemfile.lock` and local development all say 4.3.4.** The Gemfile was decorative in CI.

## Fix

Build with `ruby/setup-ruby` and `bundle exec jekyll build` — the approach the warning itself links to. CI now uses the pinned Jekyll, and the Gemfile becomes the single source of truth.

Nothing depended on what the `github-pages` bundle was silently providing:

- `_config.yml` declares no `theme` and no `plugins`
- no `site.github`, `{% seo %}`, `{% gist %}` or `.coffee` anywhere in the source
- `jekyll-theme-primer` was loaded but unused — every page carries a layout from `_layouts/`

## Verification

Built locally on 4.3.4 and diffed the rendered text of every page against the **deployed 3.10 output**:

| Page | Result |
|---|---|
| index | identical |
| curation | identical |
| datasets | identical |
| model | identical |
| package | identical |
| team | identical |
| terms | identical |
| datasets/aoki2010duration | identical |

Full build produces 91 HTML files (7 pages + 84 dataset pages).

The `build` check on this PR is the real test, since it exercises the new workflow on Linux.

## Lockfile

`Gemfile.lock` gains `x86_64-linux`. It listed only `x64-mingw-ucrt`, so a Linux `bundle install` would have had to re-resolve at build time rather than install from the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
