### PR TITLE
Show each analyte's shedding figure on its dataset page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 _datasets/
+# Fetched from the data repository by `make ^_datasets-yaml`, like _datasets.
+assets/figures/
+_data/figures.json
 _site/
 .bundle/
 .claude/

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,31 @@ _datasets : ${DATASETS_MD}
 ${DATASETS_MD} : _datasets/%.md : _datasets/%.yaml
 	echo "---\n`cat $<`\n---" | sed 's/^url:/source_url:/g' > $@
 
-# Phony target to download the yaml files.
+# Phony target to download the yaml files. The same archive also carries the
+# per-analyte figures, which are built in the data repository by `make figures`
+# -- this site has no Python to regenerate them with -- so they are copied out
+# here rather than committed a second time. index.json becomes a Jekyll data
+# file so the dataset layout can look up an analyte's figures in Liquid.
 ^_datasets-yaml : tmp/shedding-hub.zip
 	rm -rf tmp/shedding-hub-${DATA_REF}
 	unzip -d tmp $<
 	mkdir -p _datasets
 	cp -r tmp/shedding-hub-${DATA_REF}/data/*/*.yaml _datasets
+	mkdir -p assets/figures _data
+	# Tolerated rather than required: a DATA_REF predating the figures, or a
+	# branch that never carried them, should still build a site -- the layout
+	# omits the figure block when the data file is absent. Failing the whole
+	# build over a missing illustration would take the datasets down with it.
+	if [ -d tmp/shedding-hub-${DATA_REF}/figures ]; then \
+	  cp -r tmp/shedding-hub-${DATA_REF}/figures/* assets/figures/ ; \
+	  mv assets/figures/index.json _data/figures.json ; \
+	else \
+	  echo "no figures/ in ${DATA_REF}; dataset pages will omit them" ; \
+	fi
 
 tmp/shedding-hub.zip :
 	mkdir -p tmp
 	curl -L -o $@ https://github.com/shedding-hub/shedding-hub/archive/refs/heads/${DATA_REF}.zip
 
 clean :
-	rm -rf _datasets tmp
+	rm -rf _datasets tmp assets/figures _data/figures.json

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -11,16 +11,86 @@ layout: default
 
     <h2 class="has-text-primary">Analytes</h2>
 
-    <div class="grid is-col-min-18">
+    {% comment %}
+    One analyte per row rather than a two-column grid: each panel carries a
+    figure whose legend lists every fitted parameter, and at half the container
+    width that legend is too small to read.
+    {% endcomment %}
+    <div>
       {% for analyte_hash in page.analytes %}
       {% assign analyte = analyte_hash[1] %}
-      <div class="cell">
+      <div class="mb-5">
         <div id="{{ analyte_hash[0] }}" class="panel is-primary">
           <p class="panel-heading"><code>{{ analyte_hash[0] }}</code></p>
 
           <div class="panel-block">
             {{ analyte.description | markdownify }}
           </div>
+
+          {% comment %}
+          Figures are built in the data repository by `make figures` and
+          unpacked here by `make ^_datasets-yaml`; this site has no Python to
+          regenerate them with. An analyte carries either one figure per fitted
+          model -- default first, richest model first -- or a single
+          observations-only figure where no fit exists, which is the case for 88
+          of the repository's 216 analytes.
+          {% endcomment %}
+          {% assign dataset_figures = site.data.figures[page.slug] %}
+          {% if dataset_figures %}
+          {% for entry in dataset_figures.analytes %}
+          {% if entry.analyte == analyte_hash[0] and entry.figures.size > 0 %}
+          <div class="panel-block is-block shedding-figure">
+
+            {% if entry.figures.size > 1 %}
+            <div class="tabs is-small is-toggle is-centered mb-2">
+              <ul>
+                {% for figure in entry.figures %}
+                <li{% if forloop.first %} class="is-active"{% endif %}>
+                  <a data-model="{{ figure.model }}">{{ figure.model | replace: "_", " " }}</a>
+                </li>
+                {% endfor %}
+              </ul>
+            </div>
+            {% endif %}
+
+            {% comment %}
+            Linked to the full-size image because these panels sit two to a row:
+            at that width the legend, which carries every fitted parameter, is
+            too small to read. Opening in a new tab keeps the dataset page.
+            {% endcomment %}
+            {% for figure in entry.figures %}
+            {% assign figure_url = '/assets/figures/' | append: page.slug | append: '/' | append: figure.file | relative_url %}
+            <a href="{{ figure_url }}" target="_blank" rel="noopener"
+               class="figure-link" data-model="{{ figure.model }}" title="Open full size"
+               style="display: {% if forloop.first %}block{% else %}none{% endif %};">
+              <img src="{{ figure_url }}"
+                   alt="{{ figure.model | replace: '_', ' ' }} for {{ analyte_hash[0] }}"
+                   loading="lazy" style="width: 100%;">
+            </a>
+            {% endfor %}
+
+            <p class="is-size-7 has-text-grey mt-2">
+              {% if entry.figures.first.model == "observations" %}
+              Measurements only — no shedding model is fitted to this analyte,
+              usually because it is sampled once per participant, leaving no
+              trajectory to fit, or because nothing was ever detected. Open
+              triangles are non-detects, drawn at the assay's censoring limit.
+              {% else %}
+              Fitted by censored maximum likelihood. The red line is the median
+              individual; the shaded region is the full range of a simulated
+              cohort drawn from the fitted population, so it shows what
+              simulating from this dataset would produce rather than a
+              confidence interval, with dashed lines at the central 95%. Open
+              triangles are non-detects, drawn at the censoring limit and
+              entering the fit as "below this value" rather than being dropped.
+              {% endif %}
+              See the <a href="https://shedding-hub.readthedocs.io/en/latest/modeling-methods/">modelling
+              methods</a> for what these estimates do and do not support.
+            </p>
+          </div>
+          {% endif %}
+          {% endfor %}
+          {% endif %}
 
           <!-- calculate all the summary statistics in liquid -->
           {% assign num_participants = 0 %}
@@ -138,3 +208,27 @@ layout: default
 
   </div>
 </section>
+
+<script>
+  // Model selector for analytes with more than one fit. Scoped to each figure
+  // block so several analytes on one page switch independently -- a dataset can
+  // carry fourteen of them.
+  for (const block of document.querySelectorAll(".shedding-figure")) {
+    const tabs = block.querySelectorAll(".tabs a");
+    if (!tabs.length) continue;
+    for (const tab of tabs) {
+      tab.addEventListener("click", (event) => {
+        event.preventDefault();
+        const wanted = tab.dataset.model;
+        for (const other of tabs) {
+          other.parentElement.classList.toggle("is-active", other === tab);
+        }
+        // .figure-link, not a[data-model]: the tab anchors carry data-model
+        // too, so the looser selector hid every tab but the selected one.
+        for (const link of block.querySelectorAll("a.figure-link")) {
+          link.style.display = link.dataset.model === wanted ? "block" : "none";
+        }
+      });
+    }
+  }
+</script>


### PR DESCRIPTION
The Explore Dataset pages listed an analyte's metadata but showed nothing of the data itself. Each analyte panel now carries a figure.

- **Where a fit exists**: the gate-2 diagnostic with the full range of a simulated cohort and the central 95% dashed inside it, so a reader sees both the fitted curve and the spread a simulation from this dataset would produce.
- **Where none exists**: the measurements alone, in the same layout. 88 of the repository's 216 analytes have no fit — cross-sectional studies sampled once per participant, analytes never detected — and a page that rendered half-blank would read as a broken site rather than as an unfittable analyte.

Figures are built in the data repository (`make figures`) and copied out of the archive this site already downloads for the dataset YAML, so they are gitignored here alongside `_datasets` rather than committed twice; this site has no Python to regenerate them with. The copy is tolerated rather than required — a `DATA_REF` without figures still builds a site, with the figure block omitted.

Analytes are laid out one per row rather than two: each figure's legend lists every fitted parameter, and at half the container width it is unreadable. An analyte with more than one fitted model gets a tab per model, defaulting to the richest available, and each figure links to its full-size image.

**Requires** shedding-hub/shedding-hub#168 to land first, which is what puts `figures/` on the data repo's `main`. Until then this builds cleanly but shows no figures.

Verified locally against a real Jekyll build: 84/84 dataset pages carry a figure, 282 image references, zero broken links, and tab switching confirmed in-browser to be scoped per analyte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB