### PR TITLE
Match biomarker and specimen filters on whole values

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -490,22 +490,34 @@
 
         this.cards.forEach(card => {
           const title = card.querySelector('.title')?.textContent.toLowerCase() || '';
-          const description = card.querySelector('.content')?.textContent.toLowerCase() || '';
-          const biomarkers = card.dataset.biomarkers?.toLowerCase() || '';
-          const specimens = card.dataset.specimens?.toLowerCase() || '';
+          const slug = (card.dataset.slug || '').toLowerCase();
+          // Whole values rather than a substring of the joined list. Several
+          // biomarkers here contain another as a substring -- "rotavirus" sits
+          // inside both "rotavirus vaccine" and "Lanzhou lamb rotavirus
+          // vaccine", "SARS" inside "SARS-CoV-2" -- so a substring test handed
+          // vaccine-shedding studies to someone filtering for the virus, and
+          // nearly the whole repository to someone filtering for SARS.
+          // Specimens collide too: "rectal_swab" inside "anorectal_swab".
+          const biomarkers = (card.dataset.biomarkers || '')
+            .split(',').map(value => value.trim()).filter(Boolean);
+          const specimens = (card.dataset.specimens || '')
+            .split(',').map(value => value.trim()).filter(Boolean);
 
-          // Text search match
+          // Identifier or title, and deliberately not the description: that is
+          // a paragraph of prose which names related pathogens and methods, so
+          // searching it returned studies that merely mention a term alongside
+          // the ones actually about it.
           const searchMatch = !searchTerm ||
-                             title.includes(searchTerm) ||
-                             description.includes(searchTerm);
+                             slug.includes(searchTerm) ||
+                             title.includes(searchTerm);
 
-          // Biomarker filter match
+          // Exact and case-sensitive: both sides are the same YAML field, so
+          // folding case could only introduce a mismatch.
           const biomarkerMatch = !biomarkerFilter ||
-                                biomarkers.includes(biomarkerFilter.toLowerCase());
+                                biomarkers.includes(biomarkerFilter);
 
-          // Specimen filter match
           const specimenMatch = !specimenFilter ||
-                               specimens.includes(specimenFilter.toLowerCase());
+                               specimens.includes(specimenFilter);
 
           // Show/hide card
           if (searchMatch && biomarkerMatch && specimenMatch) {


### PR DESCRIPTION
The dataset filters tested whether the selected value appeared *anywhere inside* a card's comma-joined list, so any biomarker containing another as a substring returned the wrong studies. Measured across all 84 datasets:

| filter | returned before | actually match |
|---|---|---|
| `rotavirus` | 11 | **2** |
| `rotavirus vaccine` | 9 | **8** |
| `SARS` | 37 | **1** |

The last one is what makes this worth fixing. `SARS` and `SARS-CoV-2` are separate biomarkers, so filtering for the 2003 virus returned nearly the entire repository; it now returns `peiris2003clinical` alone. Specimens collided the same way — `rectal_swab` inside `anorectal_swab`.

The dropdowns were already built from the analytes' own `biomarker` and `specimen` fields; only the comparison was wrong. Filters now split on the comma the template joined with and compare whole values.

**Text search** now covers the dataset identifier as well as the title, and no longer covers the description — a description is a paragraph naming related pathogens and methods, so searching it returned studies that merely mention a term alongside the ones actually about it.

Verified in the browser against the built site:

| test | result |
|---|---|
| search `woelfel2020virological` | 1 hit, correct dataset, counter updates |
| search "viral dynamics" | 4 hits by title, incl. `kissler2021viral` |
| biomarker `rotavirus` | 2 — `chilengi2020pilot`, `gutierrez2021nosocomial`, no vaccine studies |
| biomarker `SARS` | 1 — `peiris2003clinical` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tdp6oCUGCvFSpfXBqSxoB