### PR TITLE
Add Andrew's AI work to his team bio

### DIFF
--- a/_data/team.yaml
+++ b/_data/team.yaml
@@ -13,7 +13,11 @@ andrew:
   github: YWAN446
   bio: Yuke (Andrew) Wang sets the overall direction of the Shedding Hub project and leads the teams to build the AI-powered multi-agent system for data curation.
   description: |
-    My research interests span the areas of exposure assessment, wastewater surveillance, and infectious disease transmission. A common thread in his research is in understanding the human-environment interface with respect to infectious diseases. I design, develop, and evaluate statistical and mathematical models to support evidence-informed public health decision-making in low- and middle-income countries (LMICs) and in the United States.
+    My research interests span the areas of exposure assessment, wastewater surveillance, and infectious disease transmission. A common thread in my research is understanding the human-environment interface with respect to infectious diseases. I design, develop, and evaluate statistical and mathematical models to support evidence-informed public health decision-making in low- and middle-income countries (LMICs) and in the United States.
+
+    More recently I have been developing **AI-powered evidence synthesis**: multi-agent systems that find the studies, extract the measurements, and check what was extracted against the source, with a human curator deciding what is accepted. Shedding Hub is the first application, and the approach is not specific to shedding — the same shape applies wherever the numbers worth having are locked in the text and figures of published papers.
+
+    I am more broadly interested in what **AI agents can do for public health**: not only synthesising the evidence, but putting it to work. [EpiChat](https://ywan446.github.io/epichat/) is one example — it turns a plain-language question into a validated epidemiological simulation, so a surveillance team or policy officer can explore a scenario without waiting on a modeller.
 
     I am an Investigator of the [Emory Center for Infectious Disease Modeling & Analytics and Training Hub (CIDMATH)](https://cidmath.org/) and a Core Investigator at the [Center for Global Safe Water, Sanitation, and Hygiene (CGSW)](https://www.cgswash.org/).
 till:


### PR DESCRIPTION
Updates Yuke (Andrew) Wang's description on the Team page with his current work, at his request.

Two new paragraphs:

- **AI-powered evidence synthesis** — described by what the pipeline actually does (find, extract, check against the source, human curator decides) rather than as a label, so it stays consistent with what the AI Curation page says.
- **AI agents for public health**, with [EpiChat](https://ywan446.github.io/epichat/) named and linked as the concrete example.

They are separate paragraphs on purpose: synthesis is evidence going *in*, EpiChat is evidence being put to *use*.

Also fixes "A common thread in **his** research" in the opening paragraph — third person inside a first-person bio, left over from an earlier version.

Content only; no layout or template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)