### PR TITLE
Fix the fits table on phones, the invisible is-link button, and default to dark

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,19 @@
   <meta property="og:image" content="{{ site.url }}/assets/logo/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
+  <!-- Theme is stamped here, before the body paints, rather than on
+       DOMContentLoaded. Dark is the default, so applying it later meant a white
+       page flashing on every load. A saved choice still wins. -->
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('shedding-hub-theme');
+        document.documentElement.setAttribute('data-theme', saved || 'dark');
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
 </head>
 
 <body>
@@ -601,6 +614,19 @@
       color: #ffffff;
     }
 
+    /* is-link buttons take their text from --bulma-link-text, which is pinned
+       above to fix body-link contrast -- which made the label the same colour as
+       the button it sits on: 1.02:1, invisible. Set both ends explicitly. */
+    :root:not([data-theme="dark"]) .button.is-link {
+      background-color: var(--link-color);
+      color: #ffffff;
+    }
+
+    [data-theme="dark"] .button.is-link {
+      background-color: var(--link-color);
+      color: var(--text-inverse);
+    }
+
     /* The dark-theme primary is a light blue, so it takes dark text. White here
        measured 2.33:1, below the AA threshold. */
     [data-theme="dark"] .button.is-primary {
@@ -1000,21 +1026,19 @@
         this.themeIcon = document.getElementById('theme-icon');
         this.themeText = document.getElementById('theme-text');
 
-        // Load saved theme or detect system preference
-        const savedTheme = this.getSavedTheme();
-        const systemPreference = this.getSystemPreference();
-        const initialTheme = savedTheme || systemPreference;
+        // The head script already stamped the attribute; read it back rather
+        // than deciding again, so the two cannot disagree and re-trigger a flash.
+        // Dark is the default when nobody has chosen.
+        const current = document.documentElement.getAttribute(this.THEME_ATTR)
+          || this.getSavedTheme()
+          || 'dark';
 
-        this.setTheme(initialTheme, false);
+        this.setTheme(current, false);
         this.attachListeners();
       },
 
       getSavedTheme() {
         return localStorage.getItem(this.STORAGE_KEY);
-      },
-
-      getSystemPreference() {
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
       },
 
       setTheme(theme, save = true) {
@@ -1049,13 +1073,10 @@
           });
         }
 
-        // Listen for system preference changes
-        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-          // Only apply if user hasn't set a preference
-          if (!this.getSavedTheme()) {
-            this.setTheme(e.matches ? 'dark' : 'light', false);
-          }
-        });
+        // No system-preference listener. It used to switch an unsaved visitor to
+        // match the OS, which would now pull them straight off the dark default
+        // the moment their machine reported light. The toggle remains the only
+        // thing that changes the theme.
       }
     };
 

--- a/fits.html
+++ b/fits.html
@@ -610,8 +610,17 @@ title: Fitted Curves - Shedding Hub
 }
 
 /* Column widths. They sum to 100% under table-layout: fixed, so every column is
-   on screen and none can be starved by a long value in another. */
-.fits-table { table-layout: fixed; }
+   on screen and none can be starved by a long value in another.
+
+   min-width is what makes that safe on a phone. Without it the percentages
+   resolve against a 380px viewport and thirteen columns crush together into an
+   unreadable smear; with it the table keeps a legible width and .table-scroll
+   scrolls it instead. On a desktop the container is wider, so is-fullwidth's
+   100% wins and this floor never applies. */
+.fits-table {
+  table-layout: fixed;
+  min-width: 62rem;
+}
 
 .col-id        { width: 16%; }
 .col-biomarker { width: 10%; }


### PR DESCRIPTION
Three issues found while reviewing the live site on a phone.

## The fits table crushed together on mobile

`table-layout: fixed` with percentage widths resolves those percentages against whatever the container is — so on a 390px viewport, thirteen columns compressed into an unreadable smear instead of scrolling.

A `min-width: 62rem` gives the table a floor. On a phone the `.table-scroll` box scrolls it; on a desktop the container is wider, `is-fullwidth`'s 100% wins, and the floor never applies. Measured at a 388px container: the table holds 992px and the box scrolls.

## "Submit a Pull Request" was invisible in light mode

My own regression. Pinning `--bulma-link-text` to fix body-link contrast also set the text colour of `.button.is-link`, whose background derives from the same value:

```
label      rgb(21, 101, 168)
background rgb(21,  99, 168)   → contrast 1.02:1
```

Both ends are now explicit: **6.07:1** in light, **8.51:1** in dark. No button on the page falls under AA in either theme.

## Dark is now the default

Requested. The theme is stamped in `<head>` before the body paints rather than on `DOMContentLoaded` — defaulting to dark and applying it late would flash a white page on every load. A saved choice still wins and the toggle is unchanged.

The system-preference listener is removed: it used to move an unsaved visitor to match their OS, which would now pull them straight off the dark default. `getSystemPreference` went with it rather than sitting unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)