### PR TITLE
Add Andrew's GrantOtter line, and drop the personal site link

### DIFF
--- a/_data/team.yaml
+++ b/_data/team.yaml
@@ -5,11 +5,11 @@ andrew:
   job: Assistant Research Professor
   institution: Rollins School of Public Health, Emory University
   email: yuke[dot]wang[at]emory[dot]edu
-  # Institutional profile, kept distinct from the personal site below. The
-  # homepage leadership card links here, the way the advisor cards link to
-  # theirs; the Team page still lists the personal site.
+  # The homepage leadership card links here, the way the advisor cards link to
+  # theirs. No `website` by choice: the Team page's Website link is optional
+  # (`{% if person.website %}`) and the homepage card falls back to `profile`,
+  # so leaving it out drops the link cleanly rather than breaking either page.
   profile: https://sph.emory.edu/profile/faculty/yuke-wang
-  website: https://ywan446.github.io/
   github: YWAN446
   bio: Yuke (Andrew) Wang sets the overall direction of the Shedding Hub project and leads the teams to build the AI-powered multi-agent system for data curation.
   description: |
@@ -20,6 +20,8 @@ andrew:
     I am more broadly interested in what **AI agents can do for public health**: not only synthesising the evidence, but putting it to work. [EpiChat](https://ywan446.github.io/epichat/) is one example — it turns a plain-language question into a validated epidemiological simulation, so a surveillance team or policy officer can explore a scenario without waiting on a modeller.
 
     I am an Investigator of the [Emory Center for Infectious Disease Modeling & Analytics and Training Hub (CIDMATH)](https://cidmath.org/) and a Core Investigator at the [Center for Global Safe Water, Sanitation, and Hygiene (CGSW)](https://www.cgswash.org/).
+
+    I am also the founder of [GrantOtter](https://grantotter.com).
 till:
   group: leadership
   first: Till


### PR DESCRIPTION
Two changes to the same team entry.

**The bio gains a closing line** naming Andrew as founder of [GrantOtter](https://grantotter.com), linked. It sits after the CIDMATH and CGSW affiliations rather than inside that paragraph — founding a company is a different kind of thing from an institutional appointment, and it reads better on its own line.

**The `website` field goes.** Both templates already treat it as optional, so removing it drops the link cleanly rather than leaving an empty href anywhere:

- `team.md` wraps the Website link in `{% if person.website %}`
- `index.md` resolves `person.profile | default: person.website`, so the homepage leadership card falls through to the Emory profile

Verified on a local build: Andrew's link row is now Profile + GitHub (Till still has his Website link), and the homepage founder card still points at `sph.emory.edu`.

The comment above the field described a distinction that no longer exists — it said the personal site was "kept distinct" and that "the Team page still lists the personal site" — so it is rewritten rather than left to mislead.

## One judgement call

The **EpiChat link inside the description is untouched**. It points at the same `ywan446.github.io` domain, but it links a project rather than a personal landing page, and the paragraph around it is about the work. Say the word if you want that one gone too.